### PR TITLE
cicd: updated target jdk versions of CI

### DIFF
--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        javaver: [21, 22, 23, 24]
+        javaver: [21, 22, 23, 24, 25]
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
This PR adds JDK25 to target JDK versions of CI.