### PR TITLE
cicd: modified options to plugins for GPG and Maven Central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -227,11 +227,10 @@
           <plugin>
             <groupId>org.sonatype.central</groupId>
             <artifactId>central-publishing-maven-plugin</artifactId>
-            <version>0.8.0</version>
+            <version>0.10.0</version>
             <extensions>true</extensions>
             <configuration>
               <publishingServerId>central</publishingServerId>
-              <tokenAuth>true</tokenAuth>
               <autoPublish>true</autoPublish>
             </configuration>
           </plugin>
@@ -247,7 +246,9 @@
                   <goal>sign</goal>
                 </goals>
                 <configuration>
+                  <useAgent>false</useAgent>
                   <gpgArguments>
+                    <arg>--batch</arg>
                     <arg>--pinentry-mode</arg>
                     <arg>loopback</arg>
                   </gpgArguments>


### PR DESCRIPTION
The following warning and error occurred during the publishing CI:

1. central-publishing-maven-plugin

    ```
    Warning:  Parameter 'tokenAuth' is unknown for plugin 'central-publishing-maven-plugin:0.8.0:publish (injected-central-publishing)'
    ``` 

2. org.apache.maven.plugins:maven-gpg-plugin

    ```
    gpg: signing failed: No pinentry
    ```

This PR fixes these issues.