### PR TITLE
refactor: changed the list types of error handlers to ArrayList

### DIFF
--- a/src/main/java/com/github/sttk/errs/Err.java
+++ b/src/main/java/com/github/sttk/errs/Err.java
@@ -12,8 +12,7 @@ import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.lang.management.ManagementFactory;
 import java.time.OffsetDateTime;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.ArrayList;
 
 /**
  * Is the exception class with a reason.
@@ -209,8 +208,8 @@ public final class Err extends Exception {
   }
 
   private static boolean isHandlersFixed = false;
-  private static final List<ErrHandler> syncErrHandlers = new LinkedList<>();
-  private static final List<ErrHandler> asyncErrHandlers = new LinkedList<>();
+  private static final ArrayList<ErrHandler> syncErrHandlers = new ArrayList<>();
+  private static final ArrayList<ErrHandler> asyncErrHandlers = new ArrayList<>();
 
   /**
    * Adds an {@link ErrHandler} object which is executed synchronously just after an {@link Err} is
@@ -251,6 +250,8 @@ public final class Err extends Exception {
     if (!useNotification) return;
     if (isHandlersFixed) return;
     isHandlersFixed = true;
+    syncErrHandlers.trimToSize();
+    asyncErrHandlers.trimToSize();
   }
 
   private static void notifyErr(Err err) {

--- a/src/test/java/com/github/sttk/errs/ErrHandlerTest.java
+++ b/src/test/java/com/github/sttk/errs/ErrHandlerTest.java
@@ -3,8 +3,7 @@ package com.github.sttk.errs;
 import static java.time.format.DateTimeFormatter.ISO_INSTANT;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.LinkedList;
-import java.util.List;
+import java.util.ArrayList;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -20,30 +19,30 @@ public class ErrHandlerTest {
     f = Err.class.getDeclaredField("syncErrHandlers");
     f.setAccessible(true);
     var o = f.get(null);
-    var m = LinkedList.class.getMethod("clear");
+    var m = ArrayList.class.getMethod("clear");
     m.invoke(o);
 
     f = Err.class.getDeclaredField("asyncErrHandlers");
     f.setAccessible(true);
     o = f.get(null);
-    m = LinkedList.class.getMethod("clear");
+    m = ArrayList.class.getMethod("clear");
     m.invoke(o);
   }
 
   @SuppressWarnings("unchecked")
-  List<ErrHandler> getSyncErrHandlers() throws Exception {
+  ArrayList<ErrHandler> getSyncErrHandlers() throws Exception {
     var f = Err.class.getDeclaredField("syncErrHandlers");
     f.setAccessible(true);
     var o = f.get(null);
-    return (List<ErrHandler>) o;
+    return (ArrayList<ErrHandler>) o;
   }
 
   @SuppressWarnings("unchecked")
-  List<ErrHandler> getAsyncErrHandlers() throws Exception {
+  ArrayList<ErrHandler> getAsyncErrHandlers() throws Exception {
     var f = Err.class.getDeclaredField("asyncErrHandlers");
     f.setAccessible(true);
     var o = f.get(null);
-    return (List<ErrHandler>) o;
+    return (ArrayList<ErrHandler>) o;
   }
 
   @Test
@@ -100,8 +99,8 @@ public class ErrHandlerTest {
 
   @Test
   void should_notify_exception() throws Exception {
-    final List<String> syncLogs = new LinkedList<>();
-    final List<String> asyncLogs = new LinkedList<>();
+    final ArrayList<String> syncLogs = new ArrayList<>();
+    final ArrayList<String> asyncLogs = new ArrayList<>();
 
     Err.addSyncHandler(
         (err, tm) -> {
@@ -134,9 +133,9 @@ public class ErrHandlerTest {
     Err.fixHandlers();
 
     new Err(new FailToDoSomething("abc"));
-    assertThat(syncLogs.get(0)).endsWith(":ErrHandlerTest.java(136):FailToDoSomething[name=abc]");
+    assertThat(syncLogs.get(0)).endsWith(":ErrHandlerTest.java(135):FailToDoSomething[name=abc]");
 
     Thread.sleep(100);
-    assertThat(asyncLogs.get(0)).endsWith(":ErrHandlerTest.java(136):FailToDoSomething[name=abc]");
+    assertThat(asyncLogs.get(0)).endsWith(":ErrHandlerTest.java(135):FailToDoSomething[name=abc]");
   }
 }


### PR DESCRIPTION
This PR changes the classes of the `syncErrHandlers` and `asyncErrHandlers` from `LinkedList<ErrHandler>` to `ArrayList<ErrorHandlers>`. Accordingly, this PR also changes `fixHandlers` to execute `ArrayList#trimToSize` methods of these `syncErrHandlers` and `asyncErrHandlers`.